### PR TITLE
feat: add configuration packages to ignore lidswitch and power key actions

### DIFF
--- a/data/35_ignore_lidswitch.conf
+++ b/data/35_ignore_lidswitch.conf
@@ -1,0 +1,2 @@
+HandleLidSwitch=ignore
+HandleLidSwitchDocked=ignore

--- a/data/72_ignore_powerkey.conf
+++ b/data/72_ignore_powerkey.conf
@@ -1,0 +1,1 @@
+HandlePowerKey=ignore

--- a/debian/control
+++ b/debian/control
@@ -24,4 +24,19 @@ Depends:
  powermgmt-base,
  trawldb,
  systemd,
+Recommends: logind-ignore-lidswitch, logind-ignore-powerkey
 Description: Daemon for using swayidle
+
+Package: logind-ignore-lidswitch
+Architecture: any
+Depends:
+ ${misc:Depends},
+ systemd
+Description: Configuration for systemd-logind to set HandleLidSwitch action to ignore
+
+Package: logind-ignore-powerkey
+Architecture: any
+Depends:
+ ${misc:Depends},
+ systemd
+Description: Configuration for systemd-logind to set HandlePowerKey action to ignore

--- a/debian/logind-ignore-lidswitch.install
+++ b/debian/logind-ignore-lidswitch.install
@@ -1,0 +1,1 @@
+data/35_ignore_lidswitch.conf usr/lib/systemd/logind.conf.d

--- a/debian/logind-ignore-powerkey.install
+++ b/debian/logind-ignore-powerkey.install
@@ -1,0 +1,1 @@
+data/72_ignore_powerkey.conf usr/lib/systemd/logind.conf.d


### PR DESCRIPTION
The defaults provided by logind control of lid-switch and power key actions. The changes included in these packages allow these actions to be customised by  `regolith-powerd` and `regolith-sway-clamshell`.