### PR TITLE
chore: cosmetics comment cleanup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -242,7 +242,7 @@ enum KeySymAction {
 const POWER_OFF_KEY: &str = "XF86Poweroff";
 
 impl PowerSettings {
-    /// Requires settings HandlePowerKey=ignore in logind.conf
+    // Requires settings HandlePowerKey=ignore in logind.conf
     fn handle_power_btn_action_change(&self) -> Result<(), Box<dyn Error>> {
         use PowerButtonAction::*;
         let mut sway_conn = swayipc::Connection::new()?;


### PR DESCRIPTION
This is basically needed to workaround a rare bug in the build system where if the size of the file from one commit to the other has not changed (but the content did actually change), it fails on building the package.